### PR TITLE
Correction to have the artifact file populated in the returning call

### DIFF
--- a/bridge/src/main/java/org/sonatype/sisu/maven/bridge/support/artifact/internal/LocalMavenArtifactResolverSupport.java
+++ b/bridge/src/main/java/org/sonatype/sisu/maven/bridge/support/artifact/internal/LocalMavenArtifactResolverSupport.java
@@ -61,9 +61,7 @@ public abstract class LocalMavenArtifactResolverSupport
             throw new ArtifactResolutionException( Arrays.asList( artifactResult ) );
         }
 
-        artifactRequest.getArtifact().setFile( file );
-
-        return artifactRequest.getArtifact();
+        return artifactRequest.getArtifact().setFile( file );
     }
 
     protected abstract File getBaseDir();


### PR DESCRIPTION
...on is not populating the file on the existing artifact but returning a new one which is a copy with the file populated. in this use the artifact is being returned without the file set causing an NPE in the caller.
